### PR TITLE
changes to show chinese in summary field

### DIFF
--- a/Mantis.php
+++ b/Mantis.php
@@ -312,6 +312,8 @@ function renderMantis( $input, $args, $mwParser )
 		return $errmsg;
 	}
 
+	$db->set_charset("utf8");
+
 	// create project array - accept only project names that exist in the database to prevent SQL injection
 	// this check decreases performance a tiny bit, because we have to make another db call. but security comes first!
 	if (!empty($tmpProjects))
@@ -630,6 +632,6 @@ function renderMantis( $input, $args, $mwParser )
 	$db->close();
 
 	//wfMessage("Test Message")->plain();
-	return $mwParser->recursiveTagParse(utf8_encode($output));
+	return $mwParser->recursiveTagParse($output);
 }
 ?>


### PR DESCRIPTION
This is work for me.
There are a lot of Chinese character in my MantisBT. 
I have tested four cases.
case 1:  return $mwParser->recursiveTagParse($output);
  Chinese characters are displayed as ????

case 2:  return $mwParser->recursiveTagParse(utf8_encode($output));
  Chinese characters are displayed as ä»é¢æ§å¶

case 3:  $db->set_charset("utf8"); and return $mwParser->recursiveTagParse(utf8_encode($output));
  Chinese characters are displayed as ä»é¢æ§å¶

case 4:  $db->set_charset("utf8"); and return $mwParser->recursiveTagParse($output);
  Chinese characters are displayed as 介面控制

For your information